### PR TITLE
Fix wrong err variable

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -84,7 +84,7 @@ func (e *Engine) Run() ([]Result, error) {
 		ctx := log.WithField("volume_id", res.VolumeID)
 
 		if res.Err != nil {
-			ctx.WithError(err).Error("backup")
+			ctx.WithError(res.Err).Error("backup")
 		} else {
 			ctx.Info("backup")
 		}


### PR DESCRIPTION
This was causing : 
```panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x4c7aaa]

goroutine 1 [running]:
github.com/segmentio/ebs-backup/vendor/github.com/apex/log.(*Entry).WithError(0xc420581ad8, 0x0, 0x0, 0x3)
        /home/julien/code/go/src/github.com/segmentio/ebs-backup/vendor/github.com/apex/log/entry.go:55 +0x3a
github.com/segmentio/ebs-backup/vendor/github.com/apex/log.(*Logger).WithError(0xbc4890, 0x0, 0x0, 0x7c0101)
        /home/julien/code/go/src/github.com/segmentio/ebs-backup/vendor/github.com/apex/log/logger.go:79 +0x83
github.com/segmentio/ebs-backup/vendor/github.com/apex/log.WithError(0x0, 0x0, 0xc4200f5c78)
        /home/julien/code/go/src/github.com/segmentio/ebs-backup/vendor/github.com/apex/log/pkg.go:43 +0x49
github.com/segmentio/ebs-backup/internal/engine.(*Engine).Run(0xc420072690, 0x12, 0xc4200dd2c0, 0x2, 0x2, 0xc42008e098)
        /home/julien/code/go/src/github.com/segmentio/ebs-backup/internal/engine/engine.go:87 +0x2ba
main.main()
        /home/julien/code/go/src/github.com/segmentio/ebs-backup/main.go:52 +0x36d```