### PR TITLE
Upgrade module to terraform 12

### DIFF
--- a/terraform/scheduled_backup/cloudwatch.tf
+++ b/terraform/scheduled_backup/cloudwatch.tf
@@ -5,10 +5,11 @@ resource "aws_cloudwatch_event_rule" "ebs_backup" {
 
   description         = "Back up ${var.volume_name} every ${var.frequency}"
   schedule_expression = "rate(${var.frequency})"
-  is_enabled          = "${var.enable_event_rule}"
+  is_enabled          = var.enable_event_rule
 }
 
 resource "aws_cloudwatch_event_target" "ebs_backup" {
-  rule = "${aws_cloudwatch_event_rule.ebs_backup.name}"
-  arn  = "${aws_lambda_function.ebs_backup.arn}"
+  rule = aws_cloudwatch_event_rule.ebs_backup.name
+  arn  = aws_lambda_function.ebs_backup.arn
 }
+

--- a/terraform/scheduled_backup/input.tf
+++ b/terraform/scheduled_backup/input.tf
@@ -1,23 +1,23 @@
 variable "lambda_s3_bucket_ssm_parameter" {
-  type        = "string"
+  type        = string
   default     = "/segment/ebs_backup/lambda_s3_bucket"
   description = "SSM parameter under which name of Lambda S3 bucket will be found"
 }
 
 variable "lambda_s3_key_ssm_parameter" {
-  type        = "string"
+  type        = string
   default     = "/segment/ebs_backup/lambda_s3_key"
   description = "SSM parameter under which name of Lambda S3 key will be found"
 }
 
 variable "lambda_s3_bucket" {
-  type        = "string"
+  type        = string
   description = "S3 bucket containing EBS backup Lambda function.  If specified, will override any value found in the Parameter Store."
   default     = ""
 }
 
 variable "lambda_s3_key" {
-  type        = "string"
+  type        = string
   description = "S3 key pointing to EBS backup Lambda function.  If specified, will override any value found in the Parameter Store."
   default     = ""
 }
@@ -28,13 +28,13 @@ variable "copy_tags" {
 }
 
 variable "frequency" {
-  type        = "string"
+  type        = string
   description = "Frequency at which backup is run (see https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html#RateExpressions for legal values)"
   default     = "2 hours"
 }
 
 variable "timeout" {
-  type        = "string"
+  type        = string
   description = "Maximum runtime for backup Lambda function, in seconds"
   default     = 300
 }
@@ -45,12 +45,12 @@ variable "snapshot_limit" {
 }
 
 variable "volume_name" {
-  type        = "string"
+  type        = string
   description = "Value of `Name` tag on EBS volumes to match"
 }
 
 variable "device_names" {
-  type        = "list"
+  type        = list(string)
   description = "List of device attachment names to match (e.g. `/dev/xvdf`)"
 }
 
@@ -58,3 +58,4 @@ variable "enable_event_rule" {
   default     = true
   description = "Enable event rule (not normally disabled)"
 }
+

--- a/terraform/scheduled_backup/lambda.tf
+++ b/terraform/scheduled_backup/lambda.tf
@@ -1,11 +1,11 @@
 data "aws_ssm_parameter" "lambda_s3_bucket" {
-  count = "${(var.lambda_s3_bucket != "" || var.lambda_s3_bucket_ssm_parameter == "") ? 0 : 1}"
-  name  = "${var.lambda_s3_bucket_ssm_parameter}"
+  count = var.lambda_s3_bucket != "" || var.lambda_s3_bucket_ssm_parameter == "" ? 0 : 1
+  name  = var.lambda_s3_bucket_ssm_parameter
 }
 
 data "aws_ssm_parameter" "lambda_s3_key" {
-  count = "${(var.lambda_s3_key != "" || var.lambda_s3_key_ssm_parameter == "") ? 0 : 1}"
-  name  = "${var.lambda_s3_key_ssm_parameter}"
+  count = var.lambda_s3_key != "" || var.lambda_s3_key_ssm_parameter == "" ? 0 : 1
+  name  = var.lambda_s3_key_ssm_parameter
 }
 
 locals {
@@ -13,20 +13,26 @@ locals {
 }
 
 resource "aws_lambda_function" "ebs_backup" {
-  function_name = "${format("%.64s", local.function_name)}"
+  function_name = format("%.64s", local.function_name)
   handler       = "ebs-backup-lambda"
-  role          = "${aws_iam_role.ebs_backup.arn}"
-  s3_bucket     = "${coalesce(var.lambda_s3_bucket, join("", data.aws_ssm_parameter.lambda_s3_bucket.*.value))}"
-  s3_key        = "${coalesce(var.lambda_s3_key, join("", data.aws_ssm_parameter.lambda_s3_key.*.value))}"
-  runtime       = "go1.x"
-  timeout       = "${var.timeout}"
+  role          = aws_iam_role.ebs_backup.arn
+  s3_bucket = coalesce(
+    var.lambda_s3_bucket,
+    join("", data.aws_ssm_parameter.lambda_s3_bucket.*.value),
+  )
+  s3_key = coalesce(
+    var.lambda_s3_key,
+    join("", data.aws_ssm_parameter.lambda_s3_key.*.value),
+  )
+  runtime = "go1.x"
+  timeout = var.timeout
 
   environment {
-    variables {
-      COPY_TAGS      = "${var.copy_tags}"
-      SNAPSHOT_LIMIT = "${var.snapshot_limit}"
-      VOLUME_DEVICES = "${join(" ", var.device_names)}"
-      VOLUME_NAME    = "${var.volume_name}"
+    variables = {
+      COPY_TAGS      = var.copy_tags
+      SNAPSHOT_LIMIT = var.snapshot_limit
+      VOLUME_DEVICES = join(" ", var.device_names)
+      VOLUME_NAME    = var.volume_name
     }
   }
 }
@@ -34,9 +40,9 @@ resource "aws_lambda_function" "ebs_backup" {
 resource "aws_lambda_permission" "ebs_backup" {
   statement_id  = "AllowExecutionFromCloudWatch"
   action        = "lambda:InvokeFunction"
-  function_name = "${aws_lambda_function.ebs_backup.function_name}"
+  function_name = aws_lambda_function.ebs_backup.function_name
   principal     = "events.amazonaws.com"
-  source_arn    = "${aws_cloudwatch_event_rule.ebs_backup.arn}"
+  source_arn    = aws_cloudwatch_event_rule.ebs_backup.arn
 }
 
 resource "aws_iam_role" "ebs_backup" {
@@ -56,11 +62,12 @@ resource "aws_iam_role" "ebs_backup" {
     ]
 }
 POLICY
+
 }
 
 resource "aws_iam_role_policy" "ebs_backup" {
   name = "ebs_backup"
-  role = "${aws_iam_role.ebs_backup.name}"
+  role = aws_iam_role.ebs_backup.name
 
   policy = <<POLICY
 {
@@ -89,4 +96,6 @@ resource "aws_iam_role_policy" "ebs_backup" {
     ]
 }
 POLICY
+
 }
+

--- a/terraform/scheduled_backup/output.tf
+++ b/terraform/scheduled_backup/output.tf
@@ -1,7 +1,8 @@
 output "backup_function_name" {
-  value = "${aws_lambda_function.ebs_backup.function_name}"
+  value = aws_lambda_function.ebs_backup.function_name
 }
 
 output "backup_function_arn" {
-  value = "${aws_lambda_function.ebs_backup.arn}"
+  value = aws_lambda_function.ebs_backup.arn
 }
+

--- a/terraform/scheduled_backup/versions.tf
+++ b/terraform/scheduled_backup/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
This module is only used by dedupe. Since we are migrating to terraform 0.12, we don't need to support 0.11
